### PR TITLE
fix: support minimal local-discovery config for v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ Models are loaded from local directories (default: `$HOME/models`) with automati
 - **Fallback Support**: Downloads any HuggingFace model to the custom directory if not found locally
 - **Cache Management**: Existing models in `~/.cache/huggingface/hub` can be symlinked to the custom directory
 
-### Currently Configured Models
+### Minimal Public Config
 
-Example model configurations are provided in `config.json`. Use `helper_tools/mlx_downloader.py` to download these models to your local directory before starting the server.
+The checked-in `config.json` is intentionally minimal:
+
+- it keeps the public model path anonymized as `/Users/username/models`
+- it does not hardcode any specific models
+- it relies on local model discovery from `model_directory`
+
+Download models into your local model directory with the helper tools, then restart the server and inspect `/v1/models` to see what is available.
 
 ### Model Directory Structure
 
@@ -67,7 +73,7 @@ $HOME/models/
         └── model.safetensors
 ```
 
-Use the `--config` argument to load additional model configurations from `config.json`.
+Use the `--config` argument to load additional model configurations from `config.json` when you want explicit per-model overrides.
 
 You can use the helper tools in `helper_tools/` directory:
 - `mlx_downloader.py` - Download MLX models to custom directories (supports `MLX_MODEL_DIR`)
@@ -494,10 +500,9 @@ For a complete test script, see `tests/test_vision_model.py`.
 ## Configuration
 
 The `config.json` file allows you to:
-- Define model-specific parameters (temperature, max_tokens, etc.)
 - Set memory pressure thresholds for different system states
 - Configure default values and operational settings
-- Add new models with custom chat templates
+- Add optional per-model overrides when auto-discovery is not enough
 
 ### Configuration Locations
 
@@ -531,7 +536,7 @@ Global settings that apply to all models unless overridden:
 | `streaming_format` | string | "sse" | Format: "sse", "json_lines", or "json_array" |
 | `warmup_tokens` | int | 5 | Tokens generated during model warmup |
 | `enable_function_calling` | bool | true | Enable tool/function calling support |
-| `model` | string | - | Default model to preload on startup |
+| `model` | string | - | Optional default model to preload on startup |
 | `model_directory` | string | "$HOME/models" | Path to local model storage |
 
 #### `server` Section
@@ -546,7 +551,7 @@ Network and server configuration:
 
 #### `models` Section
 
-Per-model configuration. Each model entry uses the model ID as key:
+Per-model configuration. Each model entry uses the model ID as key. This section is optional and can be empty if you want pure local auto-discovery.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -573,7 +578,7 @@ Dynamic token limits based on system memory pressure:
 | `high` | Token limit under high pressure |
 | `critical` | Token limit under critical pressure |
 
-### Example Configuration
+### Minimal Example Configuration
 
 ```json
 {
@@ -590,7 +595,6 @@ Dynamic token limits based on system memory pressure:
     "streaming_format": "sse",
     "warmup_tokens": 5,
     "enable_function_calling": true,
-    "model": "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit",
     "model_directory": "/Users/username/models"
   },
   "server": {
@@ -598,34 +602,32 @@ Dynamic token limits based on system memory pressure:
       "port": 8800,
       "debug": false
   },
+  "models": {}
+}
+```
+
+### Optional Per-Model Override Example
+
+```json
+{
   "models": {
-      "mlx-community/chandra-8bit": {
-          "max_tokens": 8192,
-          "temp": 0.7,
-          "top_p": 0.9,
-          "top_k": 50,
-          "min_p": 0.05,
-          "chat_template": "generic",
-          "required_memory_gb": 4,
-          "supports_tools": false,
-          "supports_vision": true
-      },
-      "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit": {
-          "max_tokens": 16384,
-          "temp": 0.7,
-          "top_p": 0.9,
-          "top_k": 40,
-          "min_p": 0.05,
-          "chat_template": "generic",
-          "reasoning_response": "enable",
-          "required_memory_gb": 40,
-          "memory_pressure_max_tokens": {
-                  "normal": 16384,
-                  "moderate": 16384,
-                  "high": 16384,
-                  "critical": 8192
-          }
-      },
+    "mlx-community/Qwen3.5-35B-A3B-8bit": {
+      "max_tokens": 16384,
+      "temp": 0.7,
+      "top_p": 0.9,
+      "top_k": 40,
+      "min_p": 0.05,
+      "chat_template": "qwen",
+      "required_memory_gb": 40,
+      "supports_tools": true,
+      "memory_pressure_max_tokens": {
+        "normal": 12288,
+        "moderate": 8192,
+        "high": 8192,
+        "critical": 4096
+      }
+    }
+  }
 }
 ```
 
@@ -647,6 +649,7 @@ MLX Router supports three streaming formats for maximum client compatibility:
 - **Environment Variable**: `MLX_MODEL_DIR` can override the config setting
 - **Automatic Discovery**: Models placed in this directory are automatically detected
 - **HuggingFace Cache Format**: Supports both direct directories and HF cache naming (`models--org--model`)
+- **No hardcoded public models required**: a minimal config works as long as your local model directory contains valid MLX model folders
 
 ## Memory Pressure Management
 
@@ -725,11 +728,11 @@ A comprehensive testing guide is available in [INSTALL_TEST.md](docs/INSTALL_TES
 curl -s http://localhost:8800/health | jq
 curl -s http://localhost:8800/v1/models | jq
 
-# Test chat completion
+# Test chat completion (replace with a model from /v1/models)
 curl -s -X POST http://localhost:8800/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit",
+    "model": "your-discovered-model-id",
     "messages": [{"role": "user", "content": "What existed first: the chicken or the egg?"}],
     "stream": false,
     "max_tokens": 1024

--- a/config.json
+++ b/config.json
@@ -12,7 +12,6 @@
       "streaming_format": "sse",
       "warmup_tokens": 5,
       "enable_function_calling": true,
-      "model": "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit",       
       "model_directory": "/Users/username/models"
     },
     "server": {
@@ -20,113 +19,5 @@
         "port": 8800,
         "debug": false
     },
-    "models": {
-        "mlx-community/chandra-8bit": {
-            "max_tokens": 8192,
-            "temp": 0.7,
-            "top_p": 0.9,
-            "top_k": 50,
-            "min_p": 0.05,
-            "chat_template": "generic",
-            "required_memory_gb": 4,
-            "supports_tools": false,
-            "supports_vision": true
-        },
-        "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit": {
-            "max_tokens": 16384,
-            "temp": 0.7,
-            "top_p": 0.9,
-            "top_k": 40,
-            "min_p": 0.05,
-            "chat_template": "generic",
-            "reasoning_response": "enable",
-            "required_memory_gb": 40,
-            "memory_pressure_max_tokens": {
-                    "normal": 16384,
-                    "moderate": 16384,
-                    "high": 16384,
-                    "critical": 8192
-            }
-        },
-        "mlx-community/gpt-oss-120b-MXFP4-Q8": {
-            "max_tokens": 16384,
-            "temp": 0.7,
-            "top_p": 0.9,
-            "top_k": 40,
-            "min_p": 0.05,
-            "chat_template": "gpt-oss",
-            "reasoning_response": "disable",
-            "required_memory_gb": 8,
-            "memory_pressure_max_tokens": {
-                    "normal": 16384,
-                    "moderate": 16384,
-                    "high": 16384,
-                    "critical": 8192
-            }
-        },
-        "mlx-community/Llama-3.3-70B-Instruct-4bit": {
-            "max_tokens": 16384,
-            "temp": 0.7,
-            "top_p": 0.95,
-            "top_k": 50,
-            "min_p": 0.05,
-            "chat_template": "llama3",
-            "required_memory_gb": 40,
-            "supports_tools": true,
-            "memory_pressure_max_tokens": {
-                "normal": 12288,
-                "moderate": 8192,
-                "high": 8192,
-                "critical": 4096
-            }
-        },
-        "deepseek-ai/deepseek-coder-6.7b-instruct": {
-            "max_tokens": 8192,
-            "temp": 0.1,
-            "top_p": 0.95,
-            "top_k": 20,
-            "min_p": 0.1,
-            "chat_template": "deepseek",
-            "required_memory_gb": 8,
-            "supports_tools": true,
-            "memory_pressure_max_tokens": {
-                "normal": 12288,
-                "moderate": 8192,
-                "high": 8192,
-                "critical": 4096
-            }
-        },
-        "mlx-community/Phi-4-reasoning-plus-6bit": {
-            "max_tokens": 8192,
-            "temp": 0.3,
-            "top_p": 0.9,
-            "top_k": 25,
-            "min_p": 0.08,
-            "chat_template": "phi4",
-            "required_memory_gb": 12,
-            "supports_tools": true,
-            "memory_pressure_max_tokens": {
-                "normal": 12288,
-                "moderate": 8192,
-                "high": 8192,
-                "critical": 4096
-            }
-        },
-        "mlx-community/Qwen3-30B-A3B-8bit": {
-            "max_tokens": 16384,
-            "temp": 0.7,
-            "top_p": 0.9,
-            "top_k": 40,
-            "min_p": 0.05,
-            "chat_template": "qwen",
-            "required_memory_gb": 18,
-            "supports_tools": true,
-            "memory_pressure_max_tokens": {
-                "normal": 12288,
-                "moderate": 8192,
-                "high": 8192,
-                "critical": 4096
-            }
-        }
-    }
+    "models": {}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v2.3.1] - 2026-03-08
+
+### Fixed
+- Prefer local model directories that contain actual weight files when resolving cache-style Hugging Face paths
+- Allow minimal public `config.json` files to rely on local model discovery without hardcoded model entries
+
+### Changed
+- Document minimal public configuration and helper-tool-based local model setup
+
 ## [v2.3.0] - 2026-01-04
 
 ### Added

--- a/mlx_router/__version__.py
+++ b/mlx_router/__version__.py
@@ -1,5 +1,5 @@
 """Version information for MLX Router"""
 
-VERSION = "2.3.0"
-RELEASE_DATE = "20260104"
+VERSION = "2.3.1"
+RELEASE_DATE = "20260308"
 AUTHOR = "Henry Bravo - info@henrybravo.nl"

--- a/mlx_router/cli.py
+++ b/mlx_router/cli.py
@@ -253,7 +253,7 @@ def main() -> None:
     signal.signal(signal.SIGINT, _shutdown)
     atexit.register(_shutdown)
 
-    if args.config and config_data.get("models"):
+    if args.config and (config_data.get("models") or ModelConfig.get_model_directory()):
         model_manager.refresh_available_models()
 
     set_model_manager(model_manager)
@@ -264,14 +264,17 @@ def main() -> None:
 
     # Preload default model
     default_model = config_data.get("default_model") or config_data.get("defaults", {}).get("model")
-    if not default_model and model_manager.available_models:
-        default_model = model_manager.available_models[0]
     if default_model:
         logger.info("Preloading default model: %s", default_model)
         try:
             model_manager.load_model(default_model)
         except (ValueError, RuntimeError) as exc:
             logger.warning("Failed to preload default model: %s", exc)
+    elif model_manager.available_models:
+        logger.info(
+            "Discovered %s available models. No default model configured; waiting for explicit selection.",
+            len(model_manager.available_models),
+        )
 
     print_banner()
     mem = ResourceMonitor.get_memory_info()

--- a/mlx_router/config/model_config.py
+++ b/mlx_router/config/model_config.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class ModelConfig:
     # No more hard-coded models - configurations loaded dynamically
     MODELS = {}
     _model_directory = None
-    _discovery_cache = None
+    _discovery_cache: dict[str, dict[str, Any]] | None = None
     _discovery_cache_mtime = None
     _discovery_cache_duration = 300  # Cache for 5 minutes
 
@@ -51,30 +51,38 @@ class ModelConfig:
             # First try direct directory name
             model_path = cls._model_directory / model_name
             if model_path.exists():
-                # Look for the actual model files (could be in snapshots subdirectory)
-                if (model_path / "snapshots").exists():
-                    # HuggingFace-style structure
-                    snapshots = list((model_path / "snapshots").iterdir())
-                    if snapshots:
-                        return str(snapshots[0])  # Use latest snapshot
-                else:
-                    # Direct model directory
-                    return str(model_path)
+                local_load_path = cls._resolve_local_load_path(model_path)
+                if local_load_path:
+                    return str(local_load_path)
 
             # Try HuggingFace cache directory naming convention
             hf_cache_name = f"models--{model_name.replace('/', '--')}"
             hf_model_path = cls._model_directory / hf_cache_name
             if hf_model_path.exists():
-                # HuggingFace cache structure
-                if (hf_model_path / "snapshots").exists():
-                    snapshots = list((hf_model_path / "snapshots").iterdir())
-                    if snapshots:
-                        # Sort by modification time to get latest
-                        latest_snapshot = max(snapshots, key=lambda p: p.stat().st_mtime)
-                        return str(latest_snapshot)
+                local_load_path = cls._resolve_local_load_path(hf_model_path)
+                if local_load_path:
+                    return str(local_load_path)
 
         # Fall back to HuggingFace identifier
         return model_name
+
+    @classmethod
+    def _resolve_local_load_path(cls, model_path: Path) -> Path | None:
+        if cls._has_direct_model_files(model_path):
+            return model_path
+
+        snapshots_dir = model_path / "snapshots"
+        if snapshots_dir.exists():
+            snapshots = [snapshot for snapshot in snapshots_dir.iterdir() if snapshot.is_dir()]
+            snapshots.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+            for snapshot in snapshots:
+                if cls._has_direct_model_files(snapshot):
+                    return snapshot
+
+        if (model_path / "config.json").exists():
+            return model_path
+
+        return None
 
     @classmethod
     def discover_local_models(cls) -> dict[str, dict[str, Any]]:
@@ -82,17 +90,14 @@ class ModelConfig:
         if not cls._model_directory or not cls._model_directory.exists():
             return {}
 
-        # Check if cache is valid
         current_mtime = cls._get_directory_mtime(cls._model_directory)
-        cache_valid = (
+        if (
             cls._discovery_cache is not None
             and cls._discovery_cache_mtime == current_mtime
             and time.time() - getattr(cls, "_discovery_cache_time", 0) < cls._discovery_cache_duration
-        )
-
-        if cache_valid:
+        ):
             logger.debug("Using cached model discovery results")
-            return cls._discovery_cache
+            return cast(dict[str, dict[str, Any]], cls._discovery_cache)
 
         # Cache miss - perform discovery
         logger.info(f"Scanning model directory: {cls._model_directory}")
@@ -216,6 +221,11 @@ class ModelConfig:
         """Check if directory contains model files"""
         model_extensions = {".safetensors", ".bin", ".pth", ".pt"}
         return any(file_path.is_file() and file_path.suffix in model_extensions for file_path in model_path.rglob("*"))
+
+    @classmethod
+    def _has_direct_model_files(cls, model_path: Path) -> bool:
+        model_extensions = {".safetensors", ".bin", ".pth", ".pt"}
+        return any(file_path.is_file() and file_path.suffix in model_extensions for file_path in model_path.iterdir())
 
     @classmethod
     def _detect_chat_template(cls, hf_config: dict[str, Any]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mlx-router"
-version = "2.3.0"
+version = "2.3.1"
 description = "OpenAI-compatible inference server for Apple Silicon — hot-swap MLX models, stream responses, process images and PDFs."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,41 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from mlx_router.config.model_config import ModelConfig
+
+
+class TestModelConfig(unittest.TestCase):
+    def tearDown(self):
+        ModelConfig.set_model_directory(None)
+
+    def test_resolve_model_path_prefers_parent_directory_with_weights(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model_root = Path(tmp_dir) / "models--mlx-community--Qwen3.5-35B-A3B-8bit"
+            snapshot_dir = model_root / "snapshots" / "abc123"
+            snapshot_dir.mkdir(parents=True)
+
+            (model_root / "config.json").write_text("{}")
+            (snapshot_dir / "config.json").write_text("{}")
+            (model_root / "model-00001-of-00008.safetensors").write_text("weights")
+
+            ModelConfig.set_model_directory(tmp_dir)
+
+            resolved = ModelConfig.resolve_model_path("mlx-community/Qwen3.5-35B-A3B-8bit")
+
+            self.assertEqual(Path(resolved).resolve(), model_root.resolve())
+
+    def test_resolve_model_path_uses_snapshot_when_weights_live_in_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model_root = Path(tmp_dir) / "models--mlx-community--Qwen3.5-35B-A3B-8bit"
+            snapshot_dir = model_root / "snapshots" / "abc123"
+            snapshot_dir.mkdir(parents=True)
+
+            (snapshot_dir / "config.json").write_text("{}")
+            (snapshot_dir / "model-00001-of-00008.safetensors").write_text("weights")
+
+            ModelConfig.set_model_directory(tmp_dir)
+
+            resolved = ModelConfig.resolve_model_path("mlx-community/Qwen3.5-35B-A3B-8bit")
+
+            self.assertEqual(Path(resolved).resolve(), snapshot_dir.resolve())


### PR DESCRIPTION
## Summary
- fix local cache-style model resolution so converted MLX models load from directories that actually contain their weights
- switch the public config to a minimal, anonymized local-discovery setup with no hardcoded model entries or implicit default preload
- document helper-tool-based model downloads and bump package metadata to v2.3.1 for the next patch release

## Verification
- `uvx ruff check mlx_router/config/model_config.py mlx_router/cli.py tests/test_model_config.py`
- `uvx ruff format --check mlx_router/config/model_config.py mlx_router/cli.py tests/test_model_config.py`
- `uv run pytest tests/test_model_config.py -v`
- validated minimal config against `/Users/enri/models` local discovery and verified local Qwen3.5-35B-A3B-8bit preload without fresh HF API fetches