### PR TITLE
feat: add idle-unload TTL to release model memory after inactivity

### DIFF
--- a/mlx_router/cli.py
+++ b/mlx_router/cli.py
@@ -137,6 +137,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=120, help="Generation timeout in seconds (default: 120)")
     parser.add_argument("--config", help="Path to config.json")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument(
+        "--idle-unload-seconds",
+        type=int,
+        default=0,
+        help="Auto-unload current model after N seconds of inactivity (0 = disabled). "
+        "Can also be set via config.json defaults.idle_unload_seconds.",
+    )
     return parser.parse_args()
 
 
@@ -211,6 +218,8 @@ def main() -> None:
 
             args.max_tokens = defaults.get("max_tokens", args.max_tokens)
             args.timeout = defaults.get("timeout", args.timeout)
+            if args.idle_unload_seconds == 0:
+                args.idle_unload_seconds = int(defaults.get("idle_unload_seconds", 0))
             if args.ip == "0.0.0.0":
                 args.ip = server_cfg.get("ip", args.ip)
             if args.port == 8800:
@@ -239,6 +248,8 @@ def main() -> None:
     )
 
     model_manager = MLXModelManager(max_tokens=args.max_tokens, timeout=args.timeout)
+    if args.idle_unload_seconds and args.idle_unload_seconds > 0:
+        model_manager.set_idle_unload_seconds(args.idle_unload_seconds)
 
     def _shutdown(signum: object = None, frame: object = None) -> None:
         logger.info("Shutting down MLX Router…")

--- a/mlx_router/core/manager.py
+++ b/mlx_router/core/manager.py
@@ -76,8 +76,114 @@ class MLXModelManager:
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.start_time = time.time()
         self.request_count = 0
+        # Idle-unload TTL: auto-unload current model after N seconds of inactivity (0 = disabled)
+        self.last_request_ts: float = time.time()
+        self.idle_unload_seconds: int = 0
+        self._idle_scan_thread = None
+        self._idle_scan_stop = threading.Event()
+        self._idle_scan_interval: float = 30.0
+        # Track in-flight generations so the idle scanner does not unload the model mid-generation.
+        self._active_generations: int = 0
+        self._gen_count_lock = threading.Lock()
         self.available_models = self._validate_models()
         logger.info(f"Validated {len(self.available_models)} available models")
+
+    def _touch(self) -> None:
+        """Update last-request timestamp (called on load/generation entry)."""
+        self.last_request_ts = time.time()
+
+    def _begin_generation(self) -> None:
+        """Mark a generation as in-flight so the idle scanner does not unload mid-stream.
+
+        Acquires model_lock to serialize against the scanner's unload path: if the scanner
+        is mid-unload we wait; once it releases, _generate_response_impl will see
+        current_model=None and surface a clean error instead of reading a torn state.
+        """
+        self._touch()
+        with self.model_lock:
+            with self._gen_count_lock:
+                self._active_generations += 1
+
+    def _end_generation(self) -> None:
+        """Mark a generation finished. Pair with _begin_generation in try/finally."""
+        with self._gen_count_lock:
+            if self._active_generations > 0:
+                self._active_generations -= 1
+
+    def set_idle_unload_seconds(self, seconds: int) -> None:
+        """Configure idle TTL. >0 starts background scan thread; 0 disables and stops it.
+
+        Always joins any prior scan thread before starting a new one, so 0 → N transitions
+        cannot race with a not-yet-exited scanner.
+        """
+        seconds = max(0, int(seconds))
+        self.idle_unload_seconds = seconds
+        # Stop any existing scanner first
+        if self._idle_scan_thread is not None and self._idle_scan_thread.is_alive():
+            self._idle_scan_stop.set()
+            self._idle_scan_thread.join(timeout=5.0)
+        self._idle_scan_thread = None
+        if seconds > 0:
+            self._idle_scan_stop.clear()
+            self._idle_scan_thread = threading.Thread(
+                target=self._idle_scan_loop, name="mlx-router-idle-ttl", daemon=True
+            )
+            self._idle_scan_thread.start()
+            logger.info(
+                f"Idle unload TTL enabled: {seconds}s (scan every {self._idle_scan_interval:.0f}s)"
+            )
+        else:
+            logger.info("Idle unload TTL disabled")
+
+    def _idle_scan_loop(self) -> None:
+        """Background loop: unload current model when idle exceeds TTL.
+
+        Defers unload while any generation is in flight (active_generations > 0); the next
+        scan tick will unload if the model is still idle. This avoids reading None from
+        self.current_model mid-generation since generate_response/generate_stream_response
+        do NOT hold model_lock for the whole duration.
+        """
+        while not self._idle_scan_stop.wait(self._idle_scan_interval):
+            try:
+                if self.idle_unload_seconds <= 0 or not self.current_model_name:
+                    continue
+                idle = time.time() - self.last_request_ts
+                if idle < self.idle_unload_seconds:
+                    continue
+                with self.model_lock:
+                    # Re-check inside lock — load_model / _touch may have raced
+                    if not self.current_model_name:
+                        continue
+                    idle = time.time() - self.last_request_ts
+                    if idle < self.idle_unload_seconds:
+                        continue
+                    # Don't unload while a generation is in flight; try again next tick.
+                    # If the counter appears leaked (e.g. async generator finally was skipped on
+                    # client disconnect), force-reset after a generous grace window — better to
+                    # rebuild fresh than leak GBs of model memory forever.
+                    with self._gen_count_lock:
+                        in_flight = self._active_generations
+                    if in_flight > 0:
+                        grace_threshold = max(self.idle_unload_seconds * 4, 300)
+                        if idle < grace_threshold:
+                            logger.debug(
+                                f"[idle-TTL] deferring unload, {in_flight} generation(s) in flight "
+                                f"(idle {idle:.0f}s < grace {grace_threshold:.0f}s)"
+                            )
+                            continue
+                        logger.warning(
+                            f"[idle-TTL] in-flight counter ({in_flight}) appears leaked after "
+                            f"{idle:.0f}s idle (>{grace_threshold:.0f}s grace), forcing reset and unload"
+                        )
+                        with self._gen_count_lock:
+                            self._active_generations = 0
+                    logger.info(
+                        f"[idle-TTL] auto-unloading {self.current_model_name} "
+                        f"after {idle:.0f}s idle (threshold {self.idle_unload_seconds}s)"
+                    )
+                    self._unload_current_model()
+            except Exception as e:
+                logger.warning(f"[idle-TTL] scan loop error: {e}")
 
     def refresh_available_models(self):
         """Refresh available models after configuration changes"""
@@ -92,6 +198,11 @@ class MLXModelManager:
 
     def shutdown(self):
         """Properly shutdown the executor and clean up resources"""
+        # Stop idle-TTL scan thread first so it doesn't race with executor shutdown
+        if hasattr(self, "_idle_scan_stop"):
+            self._idle_scan_stop.set()
+        if getattr(self, "_idle_scan_thread", None) is not None:
+            self._idle_scan_thread.join(timeout=5.0)
         if hasattr(self, "executor"):
             self.executor.shutdown(wait=True)
             logger.info("MLXModelManager executor shut down")
@@ -181,6 +292,7 @@ class MLXModelManager:
         return ModelConfig.suggest_best_model_for_memory(mem_info["available_gb"], prefer_performance=prefer_perf)
 
     def load_model(self, model_name):
+        self._touch()
         if not model_name:
             raise ValueError(f"Invalid model name: {model_name}")
 
@@ -514,7 +626,18 @@ class MLXModelManager:
     def generate_response(
         self, messages, tools=None, max_tokens=None, temperature=None, top_p=None, top_k=None, min_p=None, images=None
     ):
-        """Generate response with timeout protection and optional tool support"""
+        """Generate response with timeout protection and optional tool support."""
+        self._begin_generation()
+        try:
+            return self._generate_response_impl(
+                messages, tools, max_tokens, temperature, top_p, top_k, min_p, images
+            )
+        finally:
+            self._end_generation()
+
+    def _generate_response_impl(
+        self, messages, tools=None, max_tokens=None, temperature=None, top_p=None, top_k=None, min_p=None, images=None
+    ):
         if not self.current_model:
             logger.error("Generation attempted without a loaded model.")
             return {
@@ -621,12 +744,33 @@ class MLXModelManager:
         images=None,
         stream_chunk_size=None,
     ):
-        """Generate streaming response for real-time token delivery
+        """Generate streaming response for real-time token delivery.
 
         Args:
             stream_chunk_size: Buffer size for streaming tokens (default: 8). Higher values may improve
                              throughput but increase latency. Lower values give more real-time delivery.
         """
+        self._begin_generation()
+        try:
+            async for chunk in self._generate_stream_response_impl(
+                messages, tools, max_tokens, temperature, top_p, top_k, min_p, images, stream_chunk_size
+            ):
+                yield chunk
+        finally:
+            self._end_generation()
+
+    async def _generate_stream_response_impl(
+        self,
+        messages,
+        tools=None,
+        max_tokens=None,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        min_p=None,
+        images=None,
+        stream_chunk_size=None,
+    ):
         if not self.current_model:
             logger.error("Streaming generation attempted without a loaded model.")
             yield "ERROR: No model loaded. Please select a model first."


### PR DESCRIPTION
## Summary

Adds an optional **idle-unload TTL** feature: a background scanner auto-unloads the current model after N seconds of inactivity, freeing GPU/RAM. No behavior change when disabled (default).

**Motivation**: running mlx-router alongside other large models (Ollama, mlx_lm.server, fish-speech, etc.) on a single Apple Silicon machine — holding a 35B model in memory continuously while it's idle is not affordable. mlx-router is a single-model hot-swap server, but `cache_size` only governs swap behavior; there is no automatic release of an idle loaded model. This adds it.

## Configuration

- CLI: `--idle-unload-seconds N` (0 = disabled, default)
- Config: `defaults.idle_unload_seconds: N`
- CLI flag overrides config when both set.

## Implementation

- `MLXModelManager` tracks `last_request_ts` on `load_model` + `generate_response` + `generate_stream_response` entry via `_touch()`.
- A daemon scan thread (`mlx-router-idle-ttl`) wakes every 30s; when idle exceeds the configured threshold AND no generation is in flight, it acquires `model_lock` and calls `_unload_current_model()`.
- `generate_response` / `generate_stream_response` are wrapped to bump an `_active_generations` counter under `model_lock` + `_gen_count_lock`, so the scanner cannot unload mid-generation. The wrapper pattern keeps the impl methods unchanged.
- As a defensive guard against leaked counters (e.g. async generator finally skipped on FastAPI `StreamingResponse` client disconnect), the scanner force-resets and unloads after 4x TTL or 300s, whichever is greater.
- `shutdown()` stops the scanner Event and joins the thread before executor shutdown.
- `set_idle_unload_seconds()` is idempotent: it always joins any prior thread before starting a new one, so 0 → N transitions are race-free.

## Test plan

Manual e2e on Apple Silicon M2 / 64GB:

1. Add `"idle_unload_seconds": 30` to `defaults` in config.json
2. Start router: `mlx-router --config config.json --debug`
3. Send chat completion to load a 17GB model
4. Verify `current_model` is set, available memory drops by ~17GB
5. Wait 40s without further requests
6. Verify `current_model` is `None` and memory is reclaimed (~12GB freed in my run)
7. Send another request → model auto-loads again

All passed. Log line confirms scanner action: `[idle-TTL] auto-unloading <model> after 35s idle (threshold 30s)`.

## Known scope-out

`load_model()` does not currently check `_active_generations` before swapping models on caller request. This is a pre-existing race independent of this PR (caller-initiated model swap mid-generation already had this behavior); flagged here for transparency. Happy to file a follow-up issue or address in a separate PR if you'd prefer.

No new dependencies. No tests added in this PR — happy to add unit tests for the scanner state machine if you want before merge.
